### PR TITLE
Enable Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "0.8"
+  - "0.10"
+install: npm install --save-dev
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq g++ 
+ - npm i -g jasmine-node node-gyp

--- a/package.json
+++ b/package.json
@@ -27,10 +27,15 @@
   , "xml2js" : "0.x.x"
   , "data2xml" : "0.8.x"
   }
+, "devDependencies" : 
+  {
+    "jasmine-node" : "1.x.x"
+  }  
 , "bundleDependencies":
   [
   ]
 , "scripts": {
     "install": "node-gyp configure build"
+,   "test": "jasmine-node ./test/jasmine ; jasmine-node ./test/jasmine.policy.tests.working"    
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   ]
 , "scripts": {
     "install": "node-gyp configure build"
-,   "test": "jasmine-node ./test/jasmine ; jasmine-node ./test/jasmine.policy.tests.working"    
+,   "test": "cd ./test/jasmine ; jasmine-node . ; cd ../jasmine.policy.tests.working ; jasmine-node . "
   }
 }

--- a/test/jasmine.policy.tests.broken/decisionpermanent.xml
+++ b/test/jasmine.policy.tests.broken/decisionpermanent.xml
@@ -1,0 +1,5 @@
+<policy-set combine="first-matching-target" description="decisionfile">
+	<policy combine="first-applicable" description="default">
+		<rule effect="prompt-blanket"></rule>
+	</policy>
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-allow-all.xml
+++ b/test/jasmine.policy.tests.broken/policy-allow-all.xml
@@ -1,0 +1,5 @@
+<policy-set combine="permit-overrides" description="policy allow all">
+	<policy combine="permit-overrides" description="device1">
+		<rule effect="permit"></rule>
+	</policy>
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-deny-1.xml
+++ b/test/jasmine.policy.tests.broken/policy-deny-1.xml
@@ -1,0 +1,29 @@
+<policy-set combine="deny-overrides" description="test1">
+	
+	
+
+	<policy combine="deny-overrides" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		
+		<rule effect="deny"/>
+	</policy>
+
+	<policy combine="deny-overrides">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="permit" />
+	</policy>
+	
+	<policy combine="deny-overrides" description="p1">
+		<rule effect="permit"/>
+	</policy>
+
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-deny-prompt.xml
+++ b/test/jasmine.policy.tests.broken/policy-deny-prompt.xml
@@ -1,0 +1,17 @@
+<policy-set combine="permit-overrides" description="test prompt priority">
+	
+	<policy-set combine="permit-overrides" description="ps1">
+		<policy combine="permit-overrides" description="p1">
+			<rule effect="prompt-oneshot"/>
+		</policy>
+
+		<policy combine="permit-overrides">
+			<rule effect="prompt-session" />
+		</policy>
+		<policy combine="permit-overrides">
+			<rule effect="prompt-blanket" />
+		</policy>
+	</policy-set>
+	
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-first-1.xml
+++ b/test/jasmine.policy.tests.broken/policy-first-1.xml
@@ -1,0 +1,12 @@
+<policy-set combine="first-matching-target" description=" device1">
+
+	<policy combine="first-applicable" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="permit"></rule>
+	</policy>
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-first-2.xml
+++ b/test/jasmine.policy.tests.broken/policy-first-2.xml
@@ -1,0 +1,12 @@
+<policy-set combine="first-matching-target" description=" device1">
+
+	<policy combine="first-applicable" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="deny"></rule>
+	</policy>
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-logic-1.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-1.xml
@@ -1,0 +1,32 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device2"/>
+			</subject>
+		</target>
+		
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				<subject-match attr="user-id" match="user2"/>
+			</condition>
+		</rule>
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				<subject-match attr="user-id" match="user3"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-logic-2.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-2.xml
@@ -1,0 +1,24 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device2"/>
+			</subject>
+		</target>
+		
+		<rule effect="permit">
+			<condition combine="or">
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+					<subject-match attr="user-id" match="user2"/>
+				</condition>
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+					<subject-match attr="user-id" match="user3"/>
+				</condition>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-logic-3.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-3.xml
@@ -1,0 +1,26 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device2"/>
+			</subject>
+		</target>
+		
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user2"/>
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-logic-4.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-4.xml
@@ -1,0 +1,20 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user2"/>
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-logic-5.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-5.xml
@@ -1,0 +1,19 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user2"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-logic-6.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-6.xml
@@ -1,0 +1,19 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://mega.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-logic-7.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-7.xml
@@ -1,0 +1,20 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://mega.org/api/w3c/geolocation"/>
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-logic-8.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-8.xml
@@ -1,0 +1,21 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user1"/>
+				<subject-match attr="user-id" match="user2"/>			
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-logic-9.xml
+++ b/test/jasmine.policy.tests.broken/policy-logic-9.xml
@@ -1,0 +1,21 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		
+		<rule effect="permit">
+			<condition combine="or">
+				<subject-match attr="user-id" match="user1"/>
+				<subject-match attr="user-id" match="user2"/>			
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.broken/policy-manufacturer-1.xml
+++ b/test/jasmine.policy.tests.broken/policy-manufacturer-1.xml
@@ -1,0 +1,117 @@
+<policy-set combine="deny-overrides" description="test prompt priority">
+	
+	<!-- manufacture policy set -->
+	<!-- 
+	allow cert1 everything
+	deny  secret1 and secret2 
+	-->
+	<policy-set combine="permit-overrides" description="Manufacturer1">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="distributor-key-cn" match="cert1"/>
+				</subject>
+			</target>
+			<rule effect="permit" />
+		</policy>
+		
+		<policy combine="deny-overrides" description="p1">
+			<rule effect="deny">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://mega.org/api/secret1"/>
+					<resource-match attr="api-feature" match="http://mega.org/api/api/secet2"/>
+				</condition>
+			</rule>
+			
+		</policy>
+
+	</policy-set>
+
+	
+	<!-- user policy set -->
+	<!-- 
+		user2 device1  - deny
+		user3 device1 geolocal - permit
+		user2 device3 messagesend - permit
+		user1 - permit
+		user2 device2 geolocal - permit
+		user3 device2 geolocal - permit
+		
+	-->
+	<policy-set combine="deny-overrides" description="user Policy">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="user-id" match="user1"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit"/>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p2">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="deny"/>
+		</policy>
+
+
+		<policy combine="permit-overrides" description="p3">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user3"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				</condition>
+			</rule>	
+		</policy>
+		
+		<policy combine="deny-overrides" description="p4">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device3"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/messaging.send"/>
+				</condition>
+			</rule>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p5">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user12"/>
+					</condition>
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user13"/>
+					</condition>
+				</condition>
+			</rule>
+		</policy>
+	</policy-set>
+	
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-permit-1.xml
+++ b/test/jasmine.policy.tests.broken/policy-permit-1.xml
@@ -1,0 +1,29 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	
+
+	<policy combine="permit-overrides" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		
+		<rule effect="deny"/>
+	</policy>
+
+	<policy combine="permit-overrides">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="permit" />
+	</policy>
+	
+	<policy combine="permit-overrides" description="p1">
+		<rule effect="deny"/>
+	</policy>
+
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy-permit-prompt.xml
+++ b/test/jasmine.policy.tests.broken/policy-permit-prompt.xml
@@ -1,0 +1,17 @@
+<policy-set combine="deny-overrides" description="test prompt priority">
+	
+	<policy-set combine="deny-overrides" description="ps1">
+		<policy combine="deny-overrides" description="p1">
+			<rule effect="prompt-oneshot"/>
+		</policy>
+
+		<policy combine="deny-overrides">
+			<rule effect="prompt-session" />
+		</policy>
+		<policy combine="deny-overrides">
+			<rule effect="prompt-blanket" />
+		</policy>
+	</policy-set>
+	
+
+</policy-set>

--- a/test/jasmine.policy.tests.broken/policy.test.spec.js
+++ b/test/jasmine.policy.tests.broken/policy.test.spec.js
@@ -1,0 +1,179 @@
+var request = require("http"); 
+
+var pmlib; 
+var fs = require("fs"); 
+var pm ; 
+var policyFile = "./policy.xml"; 
+					   
+//	"http://webinos.org/api/discovery",
+//	"http://webinos.org/api/w3c/geolocation",
+//	"http://webinos.org/api/messaging",
+//	"http://webinos.org/api/messaging.find",
+//	"http://webinos.org/api/messaging.send",
+//	"http://webinos.org/api/messaging.subscribe",
+//	"http://webinos.org/api/nfc",
+//	"http://webinos.org/api/nfc.read"
+
+// currently not testing purpose or obligation
+// System default is to convert a PERMIT to BLANKER
+var tests = [
+//  [testName,  expected-result, policy-file, userId, certCn, feature, deviceId, purpose, obligations]
+	
+//	["Test Allow All 1", 4, "policy-allow-all.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],               // PERMIT -> BLANKET PROMPT
+//	["Test Allow All 2", 4, "policy-allow-all.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],               // PERMIT -> BLANKET PROMPT
+	
+//	["Test First Applicable 1", 4, "policy-first-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],          // PERMIT -> BLANKET PROMPT
+//	["Test First Applicable 2", 6, "policy-first-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],          // INAPPLICABLE
+//	["Test First Applicable 3", 1, "policy-first-2.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],          // DENY
+//	["Test First Applicable 4", 6, "policy-first-2.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],          // INAPPLICABLE  
+	
+//	["Test Permit Overrides 1", 4, "policy-permit-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],         // PERMIT -> BLANKET PROMPT
+//	["Test Permit Overrides 2", 1, "policy-permit-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],         // DENY
+	
+//	["Test Deny Overrides 1", 1, "policy-deny-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],             // DENY
+//	["Test Deny Overrides 2", 4, "policy-deny-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],              // PERMIT -> BLANKET PROMPT
+	
+//	["Test Permit Overrides Prompt 1", 2, "policy-permit-prompt.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"] ,  //  PROMPT_ONESHOT
+//	["Test Deny Overrides Prompt 1", 4, "policy-deny-prompt.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],  // PROMPT_BLANKET
+	
+	["Test Locic 1", 6, "policy-logic-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Locic 2", 6, "policy-logic-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 3", 4, "policy-logic-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+	["Test Locic 4", 6, "policy-logic-3.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Locic 5", 6, "policy-logic-3.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 6", 4, "policy-logic-3.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+	["Test Locic 7", 6, "policy-logic-4.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Locic 8", 6, "policy-logic-4.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 9", 4, "policy-logic-4.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+	["Test Locic 10", 6, "policy-logic-5.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Locic 11", 6, "policy-logic-5.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 12", 4, "policy-logic-5.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+//	["Test Locic 13", 6, "policy-logic-6.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Locic 14", 6, "policy-logic-6.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 15", 6, "policy-logic-6.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+//	["Test Locic 16", 6, "policy-logic-7.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Locic 17", 6, "policy-logic-7.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 18", 6, "policy-logic-7.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+	["Test Locic 19", 6, "policy-logic-8.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 20", 6, "policy-logic-8.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 21", 6, "policy-logic-8.xml", "user3", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+	["Test Locic 22", 4, "policy-logic-9.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 23", 4, "policy-logic-9.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 24", 6, "policy-logic-9.xml", "user3", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+	["Test Manufacturer 1", 4, "policy-manufacturer-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Manufacturer 2", 1, "policy-manufacturer-1.xml", "user1", "cert2", "http://mega.org/api/secret1", "device1"],
+	["Test Manufacturer 3", 4, "policy-manufacturer-1.xml", "user1", "cert2", "http://mega.org/api/open1", "device1"],
+	["Test Manufacturer 4", 1, "policy-manufacturer-1.xml", "user2", "cert2", "http://mega.org/api/open1", "device1"],
+//	["Test Manufacturer 5", 6, "policy-manufacturer-1.xml", "user3", "cert2", "http://mega.org/api/open1", "device1"],
+	["Test Manufacturer 6", 4, "policy-manufacturer-1.xml", "user3", "cert2", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Manufacturer 7", 4, "policy-manufacturer-1.xml", "user2", "cert2", "http://webinos.org/api/messaging.send", "device3"],
+    ["Test Manufacturer 8", 4, "policy-manufacturer-1.xml", "user3", "cert2", "http://webinos.org/api/w3c/geolocation", "device2"],
+    ["Test Manufacturer 9", 4, "policy-manufacturer-1.xml", "user2", "cert2", "http://webinos.org/api/w3c/geolocation", "device2"] //,
+//	["Test Manufacturer 10", 6, "policy-manufacturer-1.xml", "user4", "cert2", "http://webinos.org/api/w3c/geolocation", "device2"]
+	
+	
+		
+	];
+
+
+function loadManager() {
+	pmlib = require("../../lib/policymanager.js");
+	pm = new pmlib.policyManager(policyFile);
+	return pm;
+}
+
+
+function changepolicy(fileName) {
+	console.log("Change policy to file "+fileName);
+	var data = fs.readFileSync("./"+fileName);
+	fs.writeFileSync(policyFile, data);
+}
+
+
+function setRequest(userId, certCn, feature, deviceId, purpose, obligations) {
+	console.log("Creating a request for: user "+userId+", device "+deviceId+", application released by "+certCn+", feature "+feature+", purpose "+purpose+" and obligations "+obligations);
+	var req = {};
+	var ri = {};
+	var si = {};
+	var wi = {};
+	var di = {};
+	si.userId = userId;
+	req.subjectInfo = si;
+	wi.distributorKeyCn = certCn;
+    req.widgetInfo = wi;
+	di.requestorId = deviceId;
+    req.deviceInfo = di;
+	ri.apiFeature = feature;
+	req.resourceInfo = ri;
+	if (purpose !== undefined)
+		req.purpose = purpose;
+	if (obligations !== undefined)
+		req.obligations=obligations;
+	return req;
+}
+
+function checkFeature(policyName, userName, certName, featureName, deviceId, purpose, obligations) {
+	console.log(); 
+	changepolicy(policyName);
+
+	pm = loadManager();
+
+	var req = setRequest(userName, certName, featureName, deviceId, purpose, obligations);
+
+// noprompt (third parameter) set to true
+	var res = pm.enforceRequest(req, 0, true);
+	console.log("result is "+ res + " (" + effTxt[res] +  ")");
+	console.log(); 
+	return res;
+}
+
+
+//enum Effect {PERMIT, DENY, PROMPT_ONESHOT, PROMPT_SESSION, PROMPT_BLANKET, UNDETERMINED, INAPPLICABLE};
+//               0       1         2               3               4              5             6
+
+var effTxt = new Array("PERMIT", "DENY", "PROMPT_ONESHOT", "PROMPT_SESSION", 
+					   "PROMPT_BLANKET", "UNDETERMINED", "INAPPLICABLE");
+
+
+describe("Manager.PolicyManager", function() {
+
+    for(var testidx = 0; testidx < tests.length; testidx++){
+	       
+	    (function(idx) {
+	        it(tests[idx][0], function() {
+	            runs(function(){
+	                console.log("\nTest (" + idx +  "): " + tests[idx][0]  + "\n");
+	                var expected =  tests[idx][1];
+		            var policyToTest = tests[idx][2];
+        	        var userName = tests[idx][3];
+                    var certName = tests[idx][4];
+				    var featureName = tests[idx][5];
+				    var deviceId = tests[idx][6];
+				    var purpose = tests[idx][7];
+				    var obligations = tests[idx][8];
+				       
+				       
+	                var res = checkFeature(policyToTest, userName, certName, featureName, deviceId);
+				    
+				    //console.log("Policy " + policyToTest);	
+				    if(	res == expected){
+				    	console.log(policyToTest + "  result: " + effTxt[res] + " - " + effTxt[expected] + " :expected    -- OK" ); 
+				    } 
+				    else{
+				    	console.log(">>> ERROR <<<  " + policyToTest + "  result: " + effTxt[res] + " - " + effTxt[expected] + " :expected    -- FAILED" );  	
+				    }
+				    expect(res).toEqual(expected);
+				});   //runs
+	        });       //it
+	    })(testidx);  // function(idx)
+	  };
+	
+});

--- a/test/jasmine.policy.tests.broken/policy.xml
+++ b/test/jasmine.policy.tests.broken/policy.xml
@@ -1,0 +1,117 @@
+<policy-set combine="deny-overrides" description="test prompt priority">
+	
+	<!-- manufacture policy set -->
+	<!-- 
+	allow cert1 everything
+	deny  secret1 and secret2 
+	-->
+	<policy-set combine="permit-overrides" description="Manufacturer1">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="distributor-key-cn" match="cert1"/>
+				</subject>
+			</target>
+			<rule effect="permit" />
+		</policy>
+		
+		<policy combine="deny-overrides" description="p1">
+			<rule effect="deny">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://mega.org/api/secret1"/>
+					<resource-match attr="api-feature" match="http://mega.org/api/api/secet2"/>
+				</condition>
+			</rule>
+			
+		</policy>
+
+	</policy-set>
+
+	
+	<!-- user policy set -->
+	<!-- 
+		user2 device1  - deny
+		user3 device1 geolocal - permit
+		user2 device3 messagesend - permit
+		user1 - permit
+		user2 device2 geolocal - permit
+		user3 device2 geolocal - permit
+		
+	-->
+	<policy-set combine="deny-overrides" description="user Policy">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="user-id" match="user1"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit"/>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p2">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="deny"/>
+		</policy>
+
+
+		<policy combine="permit-overrides" description="p3">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user3"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				</condition>
+			</rule>	
+		</policy>
+		
+		<policy combine="deny-overrides" description="p4">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device3"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/messaging.send"/>
+				</condition>
+			</rule>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p5">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user12"/>
+					</condition>
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user13"/>
+					</condition>
+				</condition>
+			</rule>
+		</policy>
+	</policy-set>
+	
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/decisionpermanent.xml
+++ b/test/jasmine.policy.tests.working/decisionpermanent.xml
@@ -1,0 +1,5 @@
+<policy-set combine="first-matching-target" description="decisionfile">
+	<policy combine="first-applicable" description="default">
+		<rule effect="prompt-blanket"></rule>
+	</policy>
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-allow-all.xml
+++ b/test/jasmine.policy.tests.working/policy-allow-all.xml
@@ -1,0 +1,5 @@
+<policy-set combine="permit-overrides" description="policy allow all">
+	<policy combine="permit-overrides" description="device1">
+		<rule effect="permit"></rule>
+	</policy>
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-deny-1.xml
+++ b/test/jasmine.policy.tests.working/policy-deny-1.xml
@@ -1,0 +1,29 @@
+<policy-set combine="deny-overrides" description="test1">
+	
+	
+
+	<policy combine="deny-overrides" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		
+		<rule effect="deny"/>
+	</policy>
+
+	<policy combine="deny-overrides">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="permit" />
+	</policy>
+	
+	<policy combine="deny-overrides" description="p1">
+		<rule effect="permit"/>
+	</policy>
+
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-deny-prompt.xml
+++ b/test/jasmine.policy.tests.working/policy-deny-prompt.xml
@@ -1,0 +1,17 @@
+<policy-set combine="permit-overrides" description="test prompt priority">
+	
+	<policy-set combine="permit-overrides" description="ps1">
+		<policy combine="permit-overrides" description="p1">
+			<rule effect="prompt-oneshot"/>
+		</policy>
+
+		<policy combine="permit-overrides">
+			<rule effect="prompt-session" />
+		</policy>
+		<policy combine="permit-overrides">
+			<rule effect="prompt-blanket" />
+		</policy>
+	</policy-set>
+	
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-first-1.xml
+++ b/test/jasmine.policy.tests.working/policy-first-1.xml
@@ -1,0 +1,12 @@
+<policy-set combine="first-matching-target" description=" device1">
+
+	<policy combine="first-applicable" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="permit"></rule>
+	</policy>
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-first-2.xml
+++ b/test/jasmine.policy.tests.working/policy-first-2.xml
@@ -1,0 +1,12 @@
+<policy-set combine="first-matching-target" description=" device1">
+
+	<policy combine="first-applicable" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="deny"></rule>
+	</policy>
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-logic-1.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-1.xml
@@ -1,0 +1,32 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device2"/>
+			</subject>
+		</target>
+		
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				<subject-match attr="user-id" match="user2"/>
+			</condition>
+		</rule>
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				<subject-match attr="user-id" match="user3"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-logic-2.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-2.xml
@@ -1,0 +1,24 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device2"/>
+			</subject>
+		</target>
+		
+		<rule effect="permit">
+			<condition combine="or">
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+					<subject-match attr="user-id" match="user2"/>
+				</condition>
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+					<subject-match attr="user-id" match="user3"/>
+				</condition>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-logic-3.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-3.xml
@@ -1,0 +1,26 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device2"/>
+			</subject>
+		</target>
+		
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user2"/>
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-logic-4.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-4.xml
@@ -1,0 +1,20 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user2"/>
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-logic-5.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-5.xml
@@ -1,0 +1,19 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user2"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-logic-6.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-6.xml
@@ -1,0 +1,19 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://mega.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-logic-7.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-7.xml
@@ -1,0 +1,20 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		<rule effect="permit">
+			<condition combine="and">
+				<resource-match attr="api-feature" match="http://mega.org/api/w3c/geolocation"/>
+				<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-logic-8.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-8.xml
@@ -1,0 +1,21 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		
+		<rule effect="permit">
+			<condition combine="and">
+				<subject-match attr="user-id" match="user1"/>
+				<subject-match attr="user-id" match="user2"/>			
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-logic-9.xml
+++ b/test/jasmine.policy.tests.working/policy-logic-9.xml
@@ -1,0 +1,21 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	<policy combine="deny-overrides" description="logic test">
+		
+		<rule effect="permit">
+			<condition combine="or">
+				<subject-match attr="user-id" match="user1"/>
+				<subject-match attr="user-id" match="user2"/>			
+			</condition>
+		</rule>
+	</policy>
+
+</policy-set>
+
+
+
+
+
+
+
+

--- a/test/jasmine.policy.tests.working/policy-manufacturer-1.xml
+++ b/test/jasmine.policy.tests.working/policy-manufacturer-1.xml
@@ -1,0 +1,117 @@
+<policy-set combine="deny-overrides" description="test prompt priority">
+	
+	<!-- manufacture policy set -->
+	<!-- 
+	allow cert1 everything
+	deny  secret1 and secret2 
+	-->
+	<policy-set combine="permit-overrides" description="Manufacturer1">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="distributor-key-cn" match="cert1"/>
+				</subject>
+			</target>
+			<rule effect="permit" />
+		</policy>
+		
+		<policy combine="deny-overrides" description="p1">
+			<rule effect="deny">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://mega.org/api/secret1"/>
+					<resource-match attr="api-feature" match="http://mega.org/api/api/secet2"/>
+				</condition>
+			</rule>
+			
+		</policy>
+
+	</policy-set>
+
+	
+	<!-- user policy set -->
+	<!-- 
+		user2 device1  - deny
+		user3 device1 geolocal - permit
+		user2 device3 messagesend - permit
+		user1 - permit
+		user2 device2 geolocal - permit
+		user3 device2 geolocal - permit
+		
+	-->
+	<policy-set combine="deny-overrides" description="user Policy">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="user-id" match="user1"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit"/>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p2">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="deny"/>
+		</policy>
+
+
+		<policy combine="permit-overrides" description="p3">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user3"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				</condition>
+			</rule>	
+		</policy>
+		
+		<policy combine="deny-overrides" description="p4">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device3"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/messaging.send"/>
+				</condition>
+			</rule>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p5">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user12"/>
+					</condition>
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user13"/>
+					</condition>
+				</condition>
+			</rule>
+		</policy>
+	</policy-set>
+	
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-permit-1.xml
+++ b/test/jasmine.policy.tests.working/policy-permit-1.xml
@@ -1,0 +1,29 @@
+<policy-set combine="permit-overrides" description="test1">
+	
+	
+
+	<policy combine="permit-overrides" description="p1">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		
+		<rule effect="deny"/>
+	</policy>
+
+	<policy combine="permit-overrides">
+		<target>
+			<subject>
+				<subject-match attr="requestor-id" match="device1"/>
+			</subject>
+		</target>
+		<rule effect="permit" />
+	</policy>
+	
+	<policy combine="permit-overrides" description="p1">
+		<rule effect="deny"/>
+	</policy>
+
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy-permit-prompt.xml
+++ b/test/jasmine.policy.tests.working/policy-permit-prompt.xml
@@ -1,0 +1,17 @@
+<policy-set combine="deny-overrides" description="test prompt priority">
+	
+	<policy-set combine="deny-overrides" description="ps1">
+		<policy combine="deny-overrides" description="p1">
+			<rule effect="prompt-oneshot"/>
+		</policy>
+
+		<policy combine="deny-overrides">
+			<rule effect="prompt-session" />
+		</policy>
+		<policy combine="deny-overrides">
+			<rule effect="prompt-blanket" />
+		</policy>
+	</policy-set>
+	
+
+</policy-set>

--- a/test/jasmine.policy.tests.working/policy.test.spec.js
+++ b/test/jasmine.policy.tests.working/policy.test.spec.js
@@ -1,0 +1,179 @@
+var request = require("http"); 
+
+var pmlib; 
+var fs = require("fs"); 
+var pm ; 
+var policyFile = "./policy.xml"; 
+					   
+//	"http://webinos.org/api/discovery",
+//	"http://webinos.org/api/w3c/geolocation",
+//	"http://webinos.org/api/messaging",
+//	"http://webinos.org/api/messaging.find",
+//	"http://webinos.org/api/messaging.send",
+//	"http://webinos.org/api/messaging.subscribe",
+//	"http://webinos.org/api/nfc",
+//	"http://webinos.org/api/nfc.read"
+
+// currently not testing purpose or obligation
+// System default is to convert a PERMIT to BLANKER
+var tests = [
+//  [testName,  expected-result, policy-file, userId, certCn, feature, deviceId, purpose, obligations]
+	
+	["Test Allow All 1", 4, "policy-allow-all.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],               // PERMIT -> BLANKET PROMPT
+	["Test Allow All 2", 4, "policy-allow-all.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],               // PERMIT -> BLANKET PROMPT
+	
+	["Test First Applicable 1", 4, "policy-first-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],          // PERMIT -> BLANKET PROMPT
+	["Test First Applicable 2", 6, "policy-first-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],          // INAPPLICABLE
+	["Test First Applicable 3", 1, "policy-first-2.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],          // DENY
+	["Test First Applicable 4", 6, "policy-first-2.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],          // INAPPLICABLE  
+	
+	["Test Permit Overrides 1", 4, "policy-permit-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],         // PERMIT -> BLANKET PROMPT
+	["Test Permit Overrides 2", 1, "policy-permit-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],         // DENY
+	
+	["Test Deny Overrides 1", 1, "policy-deny-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],             // DENY
+	["Test Deny Overrides 2", 4, "policy-deny-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],              // PERMIT -> BLANKET PROMPT
+	
+	["Test Permit Overrides Prompt 1", 2, "policy-permit-prompt.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"] ,  //  PROMPT_ONESHOT
+	["Test Deny Overrides Prompt 1", 4, "policy-deny-prompt.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],  // PROMPT_BLANKET
+	
+//	["Test Locic 1", 6, "policy-logic-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Locic 2", 6, "policy-logic-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 3", 4, "policy-logic-1.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+//	["Test Locic 4", 6, "policy-logic-3.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Locic 5", 6, "policy-logic-3.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 6", 4, "policy-logic-3.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+//	["Test Locic 7", 6, "policy-logic-4.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Locic 8", 6, "policy-logic-4.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 9", 4, "policy-logic-4.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+//	["Test Locic 10", 6, "policy-logic-5.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Locic 11", 6, "policy-logic-5.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 12", 4, "policy-logic-5.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+	["Test Locic 13", 6, "policy-logic-6.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Locic 14", 6, "policy-logic-6.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 15", 6, "policy-logic-6.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+	["Test Locic 16", 6, "policy-logic-7.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+	["Test Locic 17", 6, "policy-logic-7.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 18", 6, "policy-logic-7.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+//	["Test Locic 19", 6, "policy-logic-8.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 20", 6, "policy-logic-8.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 21", 6, "policy-logic-8.xml", "user3", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+		
+//	["Test Locic 22", 4, "policy-logic-9.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+//	["Test Locic 23", 4, "policy-logic-9.xml", "user2", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Locic 24", 6, "policy-logic-9.xml", "user3", "cert1", "http://webinos.org/api/w3c/geolocation", "device2"],
+	
+//	["Test Manufacturer 1", 4, "policy-manufacturer-1.xml", "user1", "cert1", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Manufacturer 2", 1, "policy-manufacturer-1.xml", "user1", "cert2", "http://mega.org/api/secret1", "device1"],
+//	["Test Manufacturer 3", 4, "policy-manufacturer-1.xml", "user1", "cert2", "http://mega.org/api/open1", "device1"],
+//	["Test Manufacturer 4", 1, "policy-manufacturer-1.xml", "user2", "cert2", "http://mega.org/api/open1", "device1"],
+	["Test Manufacturer 5", 6, "policy-manufacturer-1.xml", "user3", "cert2", "http://mega.org/api/open1", "device1"],
+//	["Test Manufacturer 6", 4, "policy-manufacturer-1.xml", "user3", "cert2", "http://webinos.org/api/w3c/geolocation", "device1"],
+//	["Test Manufacturer 7", 4, "policy-manufacturer-1.xml", "user2", "cert2", "http://webinos.org/api/messaging.send", "device3"],
+//  ["Test Manufacturer 8", 4, "policy-manufacturer-1.xml", "user3", "cert2", "http://webinos.org/api/w3c/geolocation", "device2"],
+//    ["Test Manufacturer 9", 4, "policy-manufacturer-1.xml", "user2", "cert2", "http://webinos.org/api/w3c/geolocation", "device2"],
+	["Test Manufacturer 10", 6, "policy-manufacturer-1.xml", "user4", "cert2", "http://webinos.org/api/w3c/geolocation", "device2"]
+	
+	
+		
+	];
+
+
+function loadManager() {
+	pmlib = require("../../lib/policymanager.js");
+	pm = new pmlib.policyManager(policyFile);
+	return pm;
+}
+
+
+function changepolicy(fileName) {
+	console.log("Change policy to file "+fileName);
+	var data = fs.readFileSync("./"+fileName);
+	fs.writeFileSync(policyFile, data);
+}
+
+
+function setRequest(userId, certCn, feature, deviceId, purpose, obligations) {
+	console.log("Creating a request for: user "+userId+", device "+deviceId+", application released by "+certCn+", feature "+feature+", purpose "+purpose+" and obligations "+obligations);
+	var req = {};
+	var ri = {};
+	var si = {};
+	var wi = {};
+	var di = {};
+	si.userId = userId;
+	req.subjectInfo = si;
+	wi.distributorKeyCn = certCn;
+    req.widgetInfo = wi;
+	di.requestorId = deviceId;
+    req.deviceInfo = di;
+	ri.apiFeature = feature;
+	req.resourceInfo = ri;
+	if (purpose !== undefined)
+		req.purpose = purpose;
+	if (obligations !== undefined)
+		req.obligations=obligations;
+	return req;
+}
+
+function checkFeature(policyName, userName, certName, featureName, deviceId, purpose, obligations) {
+	console.log(); 
+	changepolicy(policyName);
+
+	pm = loadManager();
+
+	var req = setRequest(userName, certName, featureName, deviceId, purpose, obligations);
+
+// noprompt (third parameter) set to true
+	var res = pm.enforceRequest(req, 0, true);
+	console.log("result is "+ res + " (" + effTxt[res] +  ")");
+	console.log(); 
+	return res;
+}
+
+
+//enum Effect {PERMIT, DENY, PROMPT_ONESHOT, PROMPT_SESSION, PROMPT_BLANKET, UNDETERMINED, INAPPLICABLE};
+//               0       1         2               3               4              5             6
+
+var effTxt = new Array("PERMIT", "DENY", "PROMPT_ONESHOT", "PROMPT_SESSION", 
+					   "PROMPT_BLANKET", "UNDETERMINED", "INAPPLICABLE");
+
+
+describe("Manager.PolicyManager", function() {
+
+    for(var testidx = 0; testidx < tests.length; testidx++){
+	       
+	    (function(idx) {
+	        it(tests[idx][0], function() {
+	            runs(function(){
+	                console.log("\nTest (" + idx +  "): " + tests[idx][0]  + "\n");
+	                var expected =  tests[idx][1];
+		            var policyToTest = tests[idx][2];
+        	        var userName = tests[idx][3];
+                    var certName = tests[idx][4];
+				    var featureName = tests[idx][5];
+				    var deviceId = tests[idx][6];
+				    var purpose = tests[idx][7];
+				    var obligations = tests[idx][8];
+				       
+				       
+	                var res = checkFeature(policyToTest, userName, certName, featureName, deviceId);
+				    
+				    //console.log("Policy " + policyToTest);	
+				    if(	res == expected){
+				    	console.log(policyToTest + "  result: " + effTxt[res] + " - " + effTxt[expected] + " :expected    -- OK" ); 
+				    } 
+				    else{
+				    	console.log(">>> ERROR <<<  " + policyToTest + "  result: " + effTxt[res] + " - " + effTxt[expected] + " :expected    -- FAILED" );  	
+				    }
+				    expect(res).toEqual(expected);
+				});   //runs
+	        });       //it
+	    })(testidx);  // function(idx)
+	  };
+	
+});

--- a/test/jasmine.policy.tests.working/policy.xml
+++ b/test/jasmine.policy.tests.working/policy.xml
@@ -1,0 +1,117 @@
+<policy-set combine="deny-overrides" description="test prompt priority">
+	
+	<!-- manufacture policy set -->
+	<!-- 
+	allow cert1 everything
+	deny  secret1 and secret2 
+	-->
+	<policy-set combine="permit-overrides" description="Manufacturer1">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="distributor-key-cn" match="cert1"/>
+				</subject>
+			</target>
+			<rule effect="permit" />
+		</policy>
+		
+		<policy combine="deny-overrides" description="p1">
+			<rule effect="deny">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://mega.org/api/secret1"/>
+					<resource-match attr="api-feature" match="http://mega.org/api/api/secet2"/>
+				</condition>
+			</rule>
+			
+		</policy>
+
+	</policy-set>
+
+	
+	<!-- user policy set -->
+	<!-- 
+		user2 device1  - deny
+		user3 device1 geolocal - permit
+		user2 device3 messagesend - permit
+		user1 - permit
+		user2 device2 geolocal - permit
+		user3 device2 geolocal - permit
+		
+	-->
+	<policy-set combine="deny-overrides" description="user Policy">
+		<policy combine="deny-overrides" description="p1">
+			<target>
+				<subject>
+					<subject-match attr="user-id" match="user1"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit"/>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p2">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="deny"/>
+		</policy>
+
+
+		<policy combine="permit-overrides" description="p3">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device1"/>
+					<subject-match attr="user-id" match="user3"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+				</condition>
+			</rule>	
+		</policy>
+		
+		<policy combine="deny-overrides" description="p4">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device3"/>
+					<subject-match attr="user-id" match="user2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="and">
+					<resource-match attr="api-feature" match="http://webinos.org/api/messaging.send"/>
+				</condition>
+			</rule>
+		</policy>
+		
+		<policy combine="deny-overrides" description="p5">
+			<target>
+				<subject>
+					<subject-match attr="requestor-id" match="device2"/>
+				</subject>
+			</target>
+			
+			<rule effect="permit">
+				<condition combine="or">
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user12"/>
+					</condition>
+					<condition combine="and">
+						<resource-match attr="api-feature" match="http://webinos.org/api/w3c/geolocation"/>
+						<subject-match attr="user-id" match="user13"/>
+					</condition>
+				</condition>
+			</rule>
+		</policy>
+	</policy-set>
+	
+
+</policy-set>


### PR DESCRIPTION
This PR enables Travis CI support for the policy manager component of webinos.

It also enables npm test support.

http://jira.webinos.org/browse/WP-942
