### PR TITLE
Fix policy manager loading

### DIFF
--- a/lib/policymanager.js
+++ b/lib/policymanager.js
@@ -58,19 +58,74 @@
 		}
 		//Policy file location
 		policyFile = policyFilename;
+		
+		checkPolicyFileExists(policyFile, function(err) {
+	    if (err) {
+	      console.log("Error reading/creating policy file: " + err);
+	    } else {
+        self.isAWellFormedPolicyFile(policyFile
+		      , function () {
+			      pmCore = new pmNativeLib.PolicyManagerInt(policyFile);
+			      //Loads decision storage module
+			      decisionStorage = new dslib.decisionStorage(policyFile);
+			      console.log("Policy file loaded");
+		      }
+		      , function () {
+			      console.log("Policy file is not valid");
+		      }
+	      );
+	    }
+		});
 
-		self.isAWellFormedPolicyFile(policyFile
-			, function () {
-				pmCore = new pmNativeLib.PolicyManagerInt(policyFile);
-				//Loads decision storage module
-				decisionStorage = new dslib.decisionStorage(policyFile);
-				console.log("Policy file loaded");
-			}
-			, function () {
-				console.log("Policy file is not valid");
-			}
-		);
+		
 	};
+
+  /**
+   * This function checks that a policy file exists at the given path.  If it
+   * does not exist, a copy of the default policy is place in this location.
+   */
+  function checkPolicyFileExists(policyFile, cb) {
+    var fs = require('fs');
+    var path = require('path');
+    if (!fs.existsSync(policyFile)) {
+      console.log("No policy file found, copying default policy instead");
+      var defaultPolicyFile = path.resolve(path.join( __dirname , "..", "defaultpolicy.xml" ));
+      if (!fs.existsSync(defaultPolicyFile)) {
+        return cb("No policy file exists, and no default policy exists either.");
+      }
+      copy(defaultPolicyFile, policyFile, cb);
+    } else {
+      return cb();
+    }
+  }
+  
+  /**
+   * Copy file 'from' to 'to', returns by calling 'cb' exactly once, either
+   * with no arguments or with an error.
+   */
+  function copy(from, to, cb) {
+    var called = false;
+    var fs = require('fs');
+    var readStream = fs.createReadStream(from);
+    var writeStream = fs.createWriteStream(to);
+    
+    readStream.on('error', function(err) { once(err) });
+    writeStream.on('error', function(err) { once(err) });
+    writeStream.on('close', function() { once() });
+    
+    readStream.pipe(writeStream);
+    
+    function once(err) {
+      if (!called) {
+        if (typeof err === "undefined") {
+          cb();
+        } else {
+          cb(err);
+        }
+        called = true;
+      } 
+    }    
+  }
 
 	policyManager.prototype.getPolicyFilePath = function() {
 		return policyFile;

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   , "sax" : "0.x.x"
   , "xml2js" : "0.x.x"
   , "data2xml" : "0.8.x"
-  , "webinos-utilities"  : "git://github.com/webinos/webinos-utilities.git"
   }
 , "devDependencies" : 
   {
     "jasmine-node" : "1.x.x"
+  , "webinos-utilities"  : "git://github.com/webinos/webinos-utilities.git"
   }  
 , "bundleDependencies":
   [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   , "sax" : "0.x.x"
   , "xml2js" : "0.x.x"
   , "data2xml" : "0.8.x"
+  , "webinos-utilities"  : "git://github.com/webinos/webinos-utilities.git"
   }
 , "devDependencies" : 
   {


### PR DESCRIPTION
The policy manager was also failing to load because
it was using webinos-utilities, which was not present
in node_modules for this module.  This fixes that
problem.  It also automatically creates a new, valid
policy file when the policy manager starts, to get rid
of another error.

See also: https://github.com/webinos/webinos-pzp/pull/8

http://jira.webinos.org/browse/WP-968

Jira issue: WP-968
