### PR TITLE
Modify testing approach to fail on more errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.8"
-  - "0.10"
 install: npm install --save-dev
 before_install:
  - sudo apt-get update -qq

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   ]
 , "scripts": {
     "install": "node-gyp configure build"
-,   "test": "cd ./test/jasmine ; jasmine-node . ; cd ../jasmine.policy.tests.working ; jasmine-node . "
+,   "test": "./test/tools/run-all.sh"
   }
 }

--- a/test/tools/run-all.sh
+++ b/test/tools/run-all.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+################################################################################
+#  Code contributed to the webinos project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2013 John Lyle, University of Oxford
+################################################################################
+
+# Fail if anything fails
+set -e
+
+# Run the old tests
+cd ./test/jasmine
+jasmine-node .
+
+# Run Mark Slaymaker's tests
+cd ../jasmine.policy.tests.working
+jasmine-node .


### PR DESCRIPTION
The Travis test framework was not producing errors when some tests failed.
This has now been fixed.  We're also not testing for node 0.10.

Jira issue: WP-945
