### PR TITLE
Adjust for obsolete msgid parameter

### DIFF
--- a/lib/rpcInterception.js
+++ b/lib/rpcInterception.js
@@ -26,7 +26,7 @@
  * Handles a new JSON RPC message (as string)
  */
 function handleMessage() {
-    var callback = arguments[3];
+    var callback = arguments[2];
     if (arguments[0].jsonrpc && arguments[0].method) {
 
         var rpcRequest = arguments[0];


### PR DESCRIPTION
The callback function is now passed as argument 2 rather than 3 since the msgid parameter has been removed.

Jira issue: wp-956
