### PR TITLE
Fix bug in rpc interception

### DIFF
--- a/lib/rpcInterception.js
+++ b/lib/rpcInterception.js
@@ -73,11 +73,13 @@ function handleMessage() {
         }
  
         // Ask policy manager to enforce the request
-        pm.enforceRequest(request, sessionId, false, callback);
-        } else {
-      //If no feature is specified then callback now with permit.
-      callback(true);
-        }
+        pm.enforceRequest(request, sessionId, false, function(res) {
+          callback(res === 0 ? true : false);
+        });
+      } else {
+        //If no feature is specified then callback now with permit.
+        callback(true);
+    }
 }
 
 }());


### PR DESCRIPTION
Rationalise the policy manager enforcement response to a simple binary, based on 0 == permit and anything else is denied.

Jira issue: wp-956
