### PR TITLE
Fixed building in debug mode

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -69,8 +69,8 @@
         'copies': [
           {
             'files': [
-              'build/Release/pm.node',
-              'build/Release/promptMan.node',
+              'build/$(CONFIGURATION)/pm.node',
+              'build/$(CONFIGURATION)/promptMan.node',
             ],
             'destination': 'node_modules/',
           }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,6 @@
 {
   'variables': {
     'module_name': 'pm',#Specify the module name here
-    #you may override the variables found in node_module.gypi here or through command line
   },
   'targets': [
     {

--- a/lib/binding.gyp
+++ b/lib/binding.gyp
@@ -28,7 +28,7 @@
     'copies': [
       {
         'files': [
-          'build/Release/certificate_manager.node',
+          'build/$(CONFIGURATION)/certificate_manager.node',
         ],
         'destination': 'node_modules/',
       }],

--- a/src/binding.gyp
+++ b/src/binding.gyp
@@ -69,8 +69,8 @@
         'copies': [
           {
             'files': [
-              'build/Release/pm.node',
-              'build/Release/promptMan.node',
+              'build/$(CONFIGURATION)/pm.node',
+              'build/$(CONFIGURATION)/promptMan.node',
             ],
             'destination': 'node_modules/',
           }],


### PR DESCRIPTION
Fixed building in debug mode

Replaced the hardcoded Release string with $(CONFIGURATION) in order to locate the output file when building with node in debug mode.

Removed also a comment that was referring to our old building scripts, before node-gyp appeared.

Jira issue: WP-1076
