### PR TITLE
Get data for generic URI

### DIFF
--- a/lib/policymanager.js
+++ b/lib/policymanager.js
@@ -1,20 +1,20 @@
 /*******************************************************************************
  *  Code contributed to the webinos project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * Copyright 2011 Telecom Italia SpA
- * 
+ *
  ******************************************************************************/
 
 
@@ -36,13 +36,43 @@
   var notificationManager = require("webinos-utilities").webinosNotifications.notificationManager;
   var pmrlib = require('./rootPm.js');
 
+  var PzpAPI = require(require('path').join(require.main.paths[0], '..', 'lib', 'pzp_sessionHandling.js'));
 
+  var getOwnerId = function() {
+    var owner = PzpAPI.getInstance().getPzhId();
+    if (!owner) {
+      owner = PzpAPI.getDeviceName();
+    }
+    return owner;
+  }
+  var genericURI = {
+    'http://webinos.org/subject/it/PZ-Owner': getOwnerId(),
+    'http://webinos.org/subject/it/known': PzpAPI.getTrustedList('pzh')
+  }
+
+  var updateEnrollmentStatus = function () {
+      genericURI['http://webinos.org/subject/it/PZ-Owner'] = getOwnerId();
+      genericURI['http://webinos.org/subject/it/known'] = PzpAPI.getTrustedList('pzh');
+      pmrlib.updatePolicyVersion();
+  }
+
+  var updateFriends = function () {
+      genericURI['http://webinos.org/subject/it/known'] = PzpAPI.getTrustedList('pzh');
+      pmrlib.updatePolicyVersion();
+  }
+
+
+  var events = require('events');
+  var eventEmitter = new events.EventEmitter();
 
   var policyManager = function(policyFilename) {
     //Root policy file location
     this.policyFile = policyFilename;
 
     this.pmr;
+
+    eventEmitter.on('updateEnrollmentStatus', updateEnrollmentStatus);
+    eventEmitter.on('updateFriends', updateFriends);
 
     // Register to receive notifications of prompt responses.
     notificationManager.on(notificationManager.notifyType.permissionResponse, promptResponse);
@@ -110,8 +140,8 @@
           cb(err);
         }
         called = true;
-      } 
-    }    
+      }
+    }
   }
 
   policyManager.prototype.getPolicyFilePath = function() {
@@ -271,5 +301,6 @@
 
   exports.policyManager = policyManager;
   exports.updatePolicyVersion = pmrlib.updatePolicyVersion;
+  exports.policyEvent = eventEmitter;
 
 }());


### PR DESCRIPTION
Added events and event handlers in policy manager to
receive from PZP data required to manage generic URI

Jira-issue: WP-1174
