### PR TITLE
Changed tests to run from js.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   ]
 , "scripts": {
     "install": "node-gyp configure build"
-,   "test": "./test/tools/run-all.sh"
+,   "test": "node ./test/tools/run-all.js"
   }
 }

--- a/test/tools/run-all.js
+++ b/test/tools/run-all.js
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *  Code contributed to the webinos project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2013 Andreas Botsikas, National Technical University of Athens
+ *
+ ******************************************************************************/
+
+var jasmine = require("jasmine-node");
+var nodePath = require('path');
+ 
+var testFolder = function(path){
+	var jasmineOptions = {
+		specFolders: [nodePath.join(__dirname,path)],
+		showColors: true,
+		isVerbose: false
+	};
+	jasmine.executeSpecsInFolder(jasmineOptions); 
+};
+testFolder('../jasmine/');
+// Run scenarios related tests
+testFolder('../jasmine.scenarios/');
+// Run Mark Slaymaker's tests
+testFolder('../jasmine.policy.tests.working/');
+


### PR DESCRIPTION
This will allow windows users to do npm test too.

Jira-issue: WP-185

It will most probably fail the tests as jasmine.scenarios and jasmine.policy.tests.working don't actually work.
