### PR TITLE
Allow prompt decisions to be actioned after prompt timeout.

### DIFF
--- a/lib/policymanager.js
+++ b/lib/policymanager.js
@@ -29,9 +29,10 @@
   var schema = require('./schema.json');
   var env = JSV.createEnvironment("json-schema-draft-03");
   var xmlParser = new xml2js.Parser(xml2js.defaults["0.2"]);
+  var logger = require('webinos-utilities').webinosLogging(__filename) || console;
 
   var decisionStorage = null;
-  var promptTimeout = 20000;
+  var promptTimeout = 30000;
   var pmrlib = require('./rootPm.js');
 
   var events = require('events');
@@ -76,12 +77,12 @@
       eventEmitter.on('updateEnrollmentStatus', updateEnrollmentStatus);
       eventEmitter.on('updateFriends', updateFriends);
     } catch(e) {
-        console.log("Cannot get info about PZ-Owner and Known PZHs");
+        logger.log("Cannot get info about PZ-Owner and Known PZHs");
     }
 
     checkPolicyFileExists(this.policyFile, function(err) {
       if (err) {
-        console.log("Error reading/creating policy file: " + err);
+        logger.log("Error reading/creating policy file: " + err);
       } else {
 // TODO: at the moment validation of root policy file fails
 //        self.isAWellFormedPolicyFile(policyFile
@@ -89,10 +90,10 @@
             self.pmr = new pmrlib.rootPm(self.policyFile, self.genericURI);
             //Loads decision storage module
             decisionStorage = new dslib.decisionStorage(self.policyFile);
-            console.log("Policy file loaded");
+            logger.log("Policy file loaded");
 //          }
 //          , function () {
-//            console.log("Policy file is not valid");
+//            logger.log("Policy file is not valid");
 //          }
 //        );
       }
@@ -107,7 +108,7 @@
     var path = require('path');
     var existsSync = fs.existsSync || path.existsSync;
     if (!existsSync(policyFile)) {
-      console.log("No policy file found, copying default policy instead");
+      logger.log("No policy file found, copying default policy instead");
       var defaultPolicyFile = path.resolve(path.join( __dirname , "..", "defaultRootPolicy.xml" ));
       if (!existsSync(defaultPolicyFile)) {
         return cb("No policy file exists, and no default policy exists either.");
@@ -159,7 +160,7 @@
   policyManager.prototype.testRequest = function(request, cb){
     var result = {};
     if (!this.pmr) {
-      console.log("Invalid policy file: request denied");
+      logger.log("Invalid policy file: request denied");
       result["effect"] = false;
       cb(result);
       return;
@@ -172,7 +173,7 @@
   }
   policyManager.prototype.enforceRequest = function(request, sessionId, noprompt, cb) {
     if (!this.pmr) {
-      console.log("Invalid policy file: request denied")
+      logger.log("Invalid policy file: request denied")
       cb(false);
       return;
     }
@@ -187,7 +188,7 @@
         this.notifyPermissionRequest(res, request, sessionId, cb);
       }
     } else {
-      //console.log("Policy Manager enforce request: "+JSON.stringify(request)+" - result is "+res);
+      //logger.log("Policy Manager enforce request: "+JSON.stringify(request)+" - result is "+res);
       cb(res);
     }
   };
@@ -199,7 +200,7 @@
         this.pmr.reloadPolicy(self.genericURI);
 //      }
 //      , function () {
-//        console.log("Policy file is not valid");
+//        logger.log("Policy file is not valid");
 //      }
 //    );
   };
@@ -289,26 +290,34 @@
     return permit;
   }
 
-	var promptResponse = function(notify) {
+  var promptResponse = function(notify) {
+    // Response from prompt received from user.
     var token = notify.data.responseTo;
     var reply = notify.data.response;
 
-    // Response from prompt received from user.
-    // Check that the prompt hasn't timed out.
-    if (this.promptCallbacks.hasOwnProperty(token)) {
-      // Prompt still valid - get the details.
-      var cb = this.promptCallbacks[token].callback;
-      var request = this.promptCallbacks[token].request;
-      var sessionId = this.promptCallbacks[token].sessionId;
-      delete this.promptCallbacks[token];
+    // Get the original request notification.
+    var requestNotification = this.notificationManager.getNotification(notify.data.responseTo);
+
+    if (typeof requestNotification !== "undefined") {
+      var request = requestNotification.data.request;
+      var sessionId = requestNotification.data.sessionId;
 
       // Store the permission request response.
       var permit = storePermissionResponse(request, sessionId, reply);
 
-      // Callback requires PERMIT == 0 and DENY == 1
-      cb(permit === true ? 0 : 1);
-  }
-	};
+      // Check if there's an outstanding callback (it may have timed out).
+      if (this.promptCallbacks.hasOwnProperty(token)) {
+        // Prompt still valid - get the details.
+        var cb = this.promptCallbacks[token].callback;
+        delete this.promptCallbacks[token];
+
+        // Callback requires PERMIT == 0 and DENY == 1
+        cb(permit === true ? 0 : 1);
+      }
+    } else {
+      logger.error("Request notification missing for response " + token);
+    }
+  };
 
   exports.policyManager = policyManager;
   exports.updatePolicyVersion = pmrlib.updatePolicyVersion;


### PR DESCRIPTION
This allows a policy prompt to be actioned at a point in time after the initial prompt has timed out, e.g. from the dashboard.

Also standardised log output.

http://jira.webinos.org/browse/WP-1196
